### PR TITLE
Do not put numeric values into quotes

### DIFF
--- a/src/ORM/Query/Builder.php
+++ b/src/ORM/Query/Builder.php
@@ -158,6 +158,10 @@ class Builder
             return $value;
         }
 
+        if (is_numeric($value)) {
+            return $value;
+        }
+        
         return '\'' . $value . '\'';
     }
 }


### PR DESCRIPTION
If quotes are added to numeric values, SalesForce returns

"value of filter criterion for field 'XXX' must be of type double and should not be enclosed in quotes"

as an error.